### PR TITLE
feat: 게시글·회원·댓글 관리를 위한 관리자 컨트롤러 및 서비스 구현

### DIFF
--- a/postIt-backend/build.gradle
+++ b/postIt-backend/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.springframework.boot:spring-boot-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     implementation 'org.hibernate.validator:hibernate-validator'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 

--- a/postIt-backend/src/main/java/com/example/postItBackend/config/SecurityConfig.java
+++ b/postIt-backend/src/main/java/com/example/postItBackend/config/SecurityConfig.java
@@ -16,6 +16,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
@@ -33,6 +34,7 @@ import java.util.List;
 
 @Configuration
 @EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -55,8 +57,9 @@ public class SecurityConfig {
                 .cors(Customizer.withDefaults()) // cors 허용
                 .csrf(AbstractHttpConfigurer::disable) // 비활성화
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                // 경로병 권한 설정
+                // 경로별 권한 설정
                 .authorizeHttpRequests(authorizeRequests -> authorizeRequests
+                                .requestMatchers("/api/admin/**").hasRole("ADMIN")
                                 .requestMatchers(HttpMethod.GET, "/api/**").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/api/login").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/login").permitAll()

--- a/postIt-backend/src/main/java/com/example/postItBackend/domain/admin/AdminController.java
+++ b/postIt-backend/src/main/java/com/example/postItBackend/domain/admin/AdminController.java
@@ -1,19 +1,13 @@
 package com.example.postItBackend.domain.admin;
 
 import com.example.postItBackend.common.response.ApiResponse;
-import com.example.postItBackend.domain.auth.model.Member;
-import com.example.postItBackend.domain.enums.UserRole;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -23,91 +17,6 @@ import org.springframework.web.bind.annotation.*;
 public class AdminController {
 
     private final AdminService adminService;
-
-    /**
-     * 모든 사용자 조회
-     */
-    @PreAuthorize("hasRole('ADMIN')")
-    @GetMapping("/members")
-    public ResponseEntity<?> getAllMembers() {
-        return ResponseEntity.ok(ApiResponse.success(adminService.getAllMembers(), HttpStatus.OK.value(), "모든 사용자 조회 성공"));
-    }
-
-    /**
-     * 특정 사용자 조회
-     */
-    @PreAuthorize("hasRole('ADMIN')")
-    @GetMapping("/members/{id}")
-    public ResponseEntity<?> getMemberById(@PathVariable Long id) {
-        Member member = adminService.getMemberById(id);
-        return ResponseEntity.ok(ApiResponse.success(member, HttpStatus.OK.value(), "사용자 조회 성공"));
-    }
-
-    /**
-     * 사용자 권한 변경 (ADMIN/USER)
-     */
-    @PreAuthorize("hasRole('ADMIN')")
-    @PutMapping("/members/{id}/role")
-    public ResponseEntity<?> updateMemberRole(@PathVariable Long id, @RequestBody RoleUpdateRequest roleRequest) {
-        try {
-            UserRole newRole = UserRole.valueOf(roleRequest.getRole().toUpperCase());
-            Member member = adminService.updateMemberRole(id, newRole);
-            return ResponseEntity.ok(ApiResponse.success(member, HttpStatus.OK.value(), "사용자 권한이 변경되었습니다"));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(ApiResponse.error("", 400, "유효하지 않은 역할입니다"));
-        }
-    }
-
-    /**
-     * 사용자 삭제
-     */
-    @PreAuthorize("hasRole('ADMIN')")
-    @DeleteMapping("/members/{id}")
-    public ResponseEntity<?> deleteMember(@PathVariable Long id, @AuthenticationPrincipal UserDetails userDetails) {
-        try {
-            adminService.deleteMember(id, userDetails.getUsername());
-            return ResponseEntity.ok(ApiResponse.success(null, HttpStatus.OK.value(), "사용자가 삭제되었습니다"));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(ApiResponse.error("", 400, e.getMessage()));
-        }
-    }
-
-    /**
-     * 특정 게시글 삭제 (관리자만 가능)
-     */
-    @PreAuthorize("hasRole('ADMIN')")
-    @DeleteMapping("/board/{boardId}")
-    public ResponseEntity<?> deletePostAsAdmin(@PathVariable("boardId") Long id) {
-        try {
-            adminService.deletePost(id);
-            return ResponseEntity.ok(ApiResponse.success(null, HttpStatus.OK.value(), "게시글이 삭제되었습니다"));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(ApiResponse.error("", 400, e.getMessage()));
-        }
-    }
-
-    /**
-     * 모든 댓글 조회
-     */
-    @PreAuthorize("hasRole('ADMIN')")
-    @GetMapping("/comments")
-    public ResponseEntity<?> getAllComments() {
-        return ResponseEntity.ok(ApiResponse.success(adminService.getAllComments(), HttpStatus.OK.value(), "모든 댓글 조회 성공"));
-    }
-
-    /**
-     * 특정 댓글 삭제 (관리자만 가능)
-     */
-    @PreAuthorize("hasRole('ADMIN')")
-    @DeleteMapping("/comments/{commentId}")
-    public ResponseEntity<?> deleteCommentAsAdmin(@PathVariable Long commentId) {
-        try {
-            adminService.deleteComment(commentId);
-            return ResponseEntity.ok(ApiResponse.success(null, HttpStatus.OK.value(), "댓글이 삭제되었습니다"));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(ApiResponse.error("", 400, e.getMessage()));
-        }
-    }
 
     /**
      * 통계: 전체 사용자 수

--- a/postIt-backend/src/main/java/com/example/postItBackend/domain/admin/AdminController.java
+++ b/postIt-backend/src/main/java/com/example/postItBackend/domain/admin/AdminController.java
@@ -1,0 +1,181 @@
+package com.example.postItBackend.domain.admin;
+
+import com.example.postItBackend.common.response.ApiResponse;
+import com.example.postItBackend.domain.auth.model.Member;
+import com.example.postItBackend.domain.enums.UserRole;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    /**
+     * 모든 사용자 조회
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/members")
+    public ResponseEntity<?> getAllMembers() {
+        return ResponseEntity.ok(ApiResponse.success(adminService.getAllMembers(), HttpStatus.OK.value(), "모든 사용자 조회 성공"));
+    }
+
+    /**
+     * 특정 사용자 조회
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/members/{id}")
+    public ResponseEntity<?> getMemberById(@PathVariable Long id) {
+        Member member = adminService.getMemberById(id);
+        return ResponseEntity.ok(ApiResponse.success(member, HttpStatus.OK.value(), "사용자 조회 성공"));
+    }
+
+    /**
+     * 사용자 권한 변경 (ADMIN/USER)
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @PutMapping("/members/{id}/role")
+    public ResponseEntity<?> updateMemberRole(@PathVariable Long id, @RequestBody RoleUpdateRequest roleRequest) {
+        try {
+            UserRole newRole = UserRole.valueOf(roleRequest.getRole().toUpperCase());
+            Member member = adminService.updateMemberRole(id, newRole);
+            return ResponseEntity.ok(ApiResponse.success(member, HttpStatus.OK.value(), "사용자 권한이 변경되었습니다"));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(ApiResponse.error("", 400, "유효하지 않은 역할입니다"));
+        }
+    }
+
+    /**
+     * 사용자 삭제
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/members/{id}")
+    public ResponseEntity<?> deleteMember(@PathVariable Long id, @AuthenticationPrincipal UserDetails userDetails) {
+        try {
+            adminService.deleteMember(id, userDetails.getUsername());
+            return ResponseEntity.ok(ApiResponse.success(null, HttpStatus.OK.value(), "사용자가 삭제되었습니다"));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(ApiResponse.error("", 400, e.getMessage()));
+        }
+    }
+
+    /**
+     * 모든 게시글 조회 (페이징)
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/board")
+    public ResponseEntity<?> getAllPosts(@RequestParam(required = false, value = "page", defaultValue = "0") int pageNo) {
+        PageRequest pageRequest = PageRequest.of(pageNo, 20, Sort.by(Sort.Direction.DESC, "id"));
+        return ResponseEntity.ok(ApiResponse.success(adminService.getAllPosts(pageRequest), HttpStatus.OK.value(), "모든 게시글 조회 성공"));
+    }
+
+    /**
+     * 특정 게시글 삭제 (관리자만 가능)
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/board/{boardId}")
+    public ResponseEntity<?> deletePostAsAdmin(@PathVariable("boardId") Long id) {
+        try {
+            adminService.deletePost(id);
+            return ResponseEntity.ok(ApiResponse.success(null, HttpStatus.OK.value(), "게시글이 삭제되었습니다"));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(ApiResponse.error("", 400, e.getMessage()));
+        }
+    }
+
+    /**
+     * 모든 댓글 조회
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/comments")
+    public ResponseEntity<?> getAllComments() {
+        return ResponseEntity.ok(ApiResponse.success(adminService.getAllComments(), HttpStatus.OK.value(), "모든 댓글 조회 성공"));
+    }
+
+    /**
+     * 특정 댓글 삭제 (관리자만 가능)
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<?> deleteCommentAsAdmin(@PathVariable Long commentId) {
+        try {
+            adminService.deleteComment(commentId);
+            return ResponseEntity.ok(ApiResponse.success(null, HttpStatus.OK.value(), "댓글이 삭제되었습니다"));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(ApiResponse.error("", 400, e.getMessage()));
+        }
+    }
+
+    /**
+     * 통계: 전체 사용자 수
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/stats/members-count")
+    public ResponseEntity<?> getMembersCount() {
+        long count = adminService.getMembersCount();
+        return ResponseEntity.ok(ApiResponse.success(count, HttpStatus.OK.value(), "전체 사용자 수 조회 성공"));
+    }
+
+    /**
+     * 통계: 전체 게시글 수
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/stats/posts-count")
+    public ResponseEntity<?> getPostsCount() {
+        long count = adminService.getPostsCount();
+        return ResponseEntity.ok(ApiResponse.success(count, HttpStatus.OK.value(), "전체 게시글 수 조회 성공"));
+    }
+
+    /**
+     * 통계: 전체 댓글 수
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/stats/comments-count")
+    public ResponseEntity<?> getCommentsCount() {
+        long count = adminService.getCommentsCount();
+        return ResponseEntity.ok(ApiResponse.success(count, HttpStatus.OK.value(), "전체 댓글 수 조회 성공"));
+    }
+
+    /**
+     * 통계: ADMIN 사용자 수
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/stats/admin-count")
+    public ResponseEntity<?> getAdminCount() {
+        long count = adminService.getAdminCount();
+        return ResponseEntity.ok(ApiResponse.success(count, HttpStatus.OK.value(), "ADMIN 사용자 수 조회 성공"));
+    }
+
+    /**
+     * 통계: USER 사용자 수
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/stats/user-count")
+    public ResponseEntity<?> getUserCount() {
+        long count = adminService.getUserCount();
+        return ResponseEntity.ok(ApiResponse.success(count, HttpStatus.OK.value(), "USER 사용자 수 조회 성공"));
+    }
+
+    /**
+     * 권한 변경 요청 DTO
+     */
+    @Getter
+    @Setter
+    public static class RoleUpdateRequest {
+        private String role;
+    }
+}
+

--- a/postIt-backend/src/main/java/com/example/postItBackend/domain/admin/AdminController.java
+++ b/postIt-backend/src/main/java/com/example/postItBackend/domain/admin/AdminController.java
@@ -73,16 +73,6 @@ public class AdminController {
     }
 
     /**
-     * 모든 게시글 조회 (페이징)
-     */
-    @PreAuthorize("hasRole('ADMIN')")
-    @GetMapping("/board")
-    public ResponseEntity<?> getAllPosts(@RequestParam(required = false, value = "page", defaultValue = "0") int pageNo) {
-        PageRequest pageRequest = PageRequest.of(pageNo, 20, Sort.by(Sort.Direction.DESC, "id"));
-        return ResponseEntity.ok(ApiResponse.success(adminService.getAllPosts(pageRequest), HttpStatus.OK.value(), "모든 게시글 조회 성공"));
-    }
-
-    /**
      * 특정 게시글 삭제 (관리자만 가능)
      */
     @PreAuthorize("hasRole('ADMIN')")

--- a/postIt-backend/src/main/java/com/example/postItBackend/domain/admin/AdminService.java
+++ b/postIt-backend/src/main/java/com/example/postItBackend/domain/admin/AdminService.java
@@ -1,0 +1,244 @@
+package com.example.postItBackend.domain.admin;
+
+import com.example.postItBackend.domain.auth.MemberRepository;
+import com.example.postItBackend.domain.auth.model.Member;
+import com.example.postItBackend.domain.comment.Comment;
+import com.example.postItBackend.domain.comment.dto.CommentResponseDto;
+import com.example.postItBackend.domain.comment.repository.CommentRepository;
+import com.example.postItBackend.domain.enums.UserRole;
+import com.example.postItBackend.domain.post.Post;
+import com.example.postItBackend.domain.post.dto.PostListPageDto;
+import com.example.postItBackend.domain.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+
+    // ==================== 사용자 관리 ====================
+
+    /**
+     * 모든 사용자 조회
+     */
+    @Transactional(readOnly = true)
+    public List<Member> getAllMembers() {
+        return memberRepository.findAll();
+    }
+
+    /**
+     * 특정 사용자 조회
+     */
+    @Transactional(readOnly = true)
+    public Member getMemberById(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+    }
+
+    /**
+     * 사용자 역할 변경 (ADMIN/USER)
+     */
+    @Transactional
+    public Member updateMemberRole(Long id, UserRole newRole) {
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+
+        Member updatedMember = Member.builder()
+                .id(member.getId())
+                .username(member.getUsername())
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .password(member.getPassword())
+                .loginType(member.getLoginType())
+                .role(newRole)
+                .build();
+
+        return memberRepository.save(updatedMember);
+    }
+
+    /**
+     * 사용자 삭제 (본인 제외)
+     */
+    @Transactional
+    public void deleteMember(Long id, String currentUsername) {
+        Member currentUser = memberRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new IllegalArgumentException("현재 사용자를 찾을 수 없습니다"));
+
+        if (currentUser.getId().equals(id)) {
+            throw new IllegalArgumentException("본인을 삭제할 수 없습니다");
+        }
+
+        memberRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+
+        memberRepository.deleteById(id);
+        log.info("User {} deleted by admin {}", id, currentUsername);
+    }
+
+    // ==================== 게시글 관리 ====================
+
+    /**
+     * 모든 게시글 조회 (페이징)
+     */
+    @Transactional(readOnly = true)
+    public List<PostListPageDto> getAllPosts(Pageable pageable) {
+        Page<PostListPageDto> postList = postRepository.getPostList(pageable);
+        return postList.toList();
+    }
+
+    /**
+     * 특정 게시글 조회
+     */
+    @Transactional(readOnly = true)
+    public Post getPostById(Long id) {
+        return postRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다"));
+    }
+
+    /**
+     * 게시글 삭제 (관리자 권한으로 아무 게시글 삭제 가능)
+     */
+    @Transactional
+    public void deletePost(Long id) {
+        if (!postRepository.existsById(id)) {
+            throw new IllegalArgumentException("게시글을 찾을 수 없습니다");
+        }
+        postRepository.deleteById(id);
+        log.info("Post {} deleted by admin", id);
+    }
+
+    /**
+     * 특정 사용자의 모든 게시글 조회
+     */
+    @Transactional(readOnly = true)
+    public List<Post> getPostsByMemberId(Long memberId) {
+        return postRepository.findAll().stream()
+                .filter(post -> post.getMember().getId().equals(memberId))
+                .toList();
+    }
+
+    // ==================== 댓글 관리 ====================
+
+    /**
+     * 모든 댓글 조회
+     */
+    @Transactional(readOnly = true)
+    public List<CommentResponseDto> getAllComments() {
+        List<Comment> all = commentRepository.findAll();
+        return all.stream().map(CommentResponseDto::new).toList();
+    }
+
+    /**
+     * 특정 게시글의 모든 댓글 조회
+     */
+    @Transactional(readOnly = true)
+    public List<CommentResponseDto> getCommentsByPostId(Long postId) {
+        return commentRepository.findCommentsByPostIdWithProjection(postId);
+    }
+
+    /**
+     * 특정 사용자의 모든 댓글 조회
+     */
+    @Transactional(readOnly = true)
+    public List<CommentResponseDto> getCommentsByMemberId(Long memberId) {
+        List<Comment> all = commentRepository.findAll();
+        return all.stream()
+                .filter(comment -> comment.getMember().getId().equals(memberId))
+                .map(CommentResponseDto::new)
+                .toList();
+    }
+
+    /**
+     * 댓글 삭제 (관리자 권한으로 아무 댓글 삭제 가능)
+     */
+    @Transactional
+    public void deleteComment(Long commentId) {
+        if (!commentRepository.existsById(commentId)) {
+            throw new IllegalArgumentException("댓글을 찾을 수 없습니다");
+        }
+        commentRepository.deleteById(commentId);
+        log.info("Comment {} deleted by admin", commentId);
+    }
+
+    /**
+     * 특정 게시글의 모든 댓글 삭제
+     */
+    @Transactional
+    public void deleteAllCommentsByPostId(Long postId) {
+        List<Comment> comments = commentRepository.findAll().stream()
+                .filter(comment -> comment.getPost().getId().equals(postId))
+                .toList();
+        commentRepository.deleteAll(comments);
+        log.info("All comments for post {} deleted by admin", postId);
+    }
+
+    /**
+     * 특정 사용자의 모든 댓글 삭제
+     */
+    @Transactional
+    public void deleteAllCommentsByMemberId(Long memberId) {
+        List<Comment> comments = commentRepository.findAll().stream()
+                .filter(comment -> comment.getMember().getId().equals(memberId))
+                .toList();
+        commentRepository.deleteAll(comments);
+        log.info("All comments for member {} deleted by admin", memberId);
+    }
+
+    // ==================== 통계 ====================
+
+    /**
+     * 전체 사용자 수
+     */
+    @Transactional(readOnly = true)
+    public long getMembersCount() {
+        return memberRepository.count();
+    }
+
+    /**
+     * 전체 게시글 수
+     */
+    @Transactional(readOnly = true)
+    public long getPostsCount() {
+        return postRepository.count();
+    }
+
+    /**
+     * 전체 댓글 수
+     */
+    @Transactional(readOnly = true)
+    public long getCommentsCount() {
+        return commentRepository.count();
+    }
+
+    /**
+     * ADMIN 사용자 수
+     */
+    @Transactional(readOnly = true)
+    public long getAdminCount() {
+        return memberRepository.findAll().stream()
+                .filter(member -> member.getRole() == UserRole.ADMIN)
+                .count();
+    }
+
+    /**
+     * USER 사용자 수
+     */
+    @Transactional(readOnly = true)
+    public long getUserCount() {
+        return memberRepository.findAll().stream()
+                .filter(member -> member.getRole() == UserRole.USER)
+                .count();
+    }
+}
+

--- a/postIt-backend/src/main/java/com/example/postItBackend/domain/admin/comment/AdminCommentController.java
+++ b/postIt-backend/src/main/java/com/example/postItBackend/domain/admin/comment/AdminCommentController.java
@@ -1,0 +1,98 @@
+package com.example.postItBackend.domain.admin.comment;
+
+import com.example.postItBackend.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/comments")
+public class AdminCommentController {
+
+    private final AdminCommentService adminCommentService;
+
+    /**
+     * 모든 댓글 조회
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping
+    public ResponseEntity<?> getAllComments() {
+        return ResponseEntity.ok(ApiResponse.success(adminCommentService.getAllComments(), HttpStatus.OK.value(), "모든 댓글 조회 성공"));
+    }
+
+//    /**
+//     * 특정 게시글의 모든 댓글 조회
+//     */
+//    @PreAuthorize("hasRole('ADMIN')")
+//    @GetMapping("/post/{postId}")
+//    public ResponseEntity<?> getCommentsByPostId(@PathVariable Long postId) {
+//        return ResponseEntity.ok(ApiResponse.success(adminCommentService.getCommentsByPostId(postId), HttpStatus.OK.value(), "게시글 댓글 조회 성공"));
+//    }
+
+    /**
+     * 특정 사용자의 모든 댓글 조회
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/member/{memberId}")
+    public ResponseEntity<?> getCommentsByMemberId(@PathVariable Long memberId) {
+        return ResponseEntity.ok(ApiResponse.success(adminCommentService.getCommentsByMemberId(memberId), HttpStatus.OK.value(), "사용자 댓글 조회 성공"));
+    }
+
+    /**
+     * 댓글 삭제 (관리자만 가능)
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<?> deleteCommentAsAdmin(@PathVariable Long commentId) {
+        try {
+            adminCommentService.deleteComment(commentId);
+            return ResponseEntity.ok(ApiResponse.success(null, HttpStatus.OK.value(), "댓글이 삭제되었습니다"));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(ApiResponse.error("", 400, e.getMessage()));
+        }
+    }
+
+    /**
+     * 특정 게시글의 모든 댓글 삭제
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/post/{postId}")
+    public ResponseEntity<?> deleteAllCommentsByPostId(@PathVariable Long postId) {
+        try {
+            adminCommentService.deleteAllCommentsByPostId(postId);
+            return ResponseEntity.ok(ApiResponse.success(null, HttpStatus.OK.value(), "게시글의 모든 댓글이 삭제되었습니다"));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(ApiResponse.error("", 400, e.getMessage()));
+        }
+    }
+
+    /**
+     * 특정 사용자의 모든 댓글 삭제
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/member/{memberId}")
+    public ResponseEntity<?> deleteAllCommentsByMemberId(@PathVariable Long memberId) {
+        try {
+            adminCommentService.deleteAllCommentsByMemberId(memberId);
+            return ResponseEntity.ok(ApiResponse.success(null, HttpStatus.OK.value(), "사용자의 모든 댓글이 삭제되었습니다"));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(ApiResponse.error("", 400, e.getMessage()));
+        }
+    }
+
+    /**
+     * 통계: 전체 댓글 수
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/stats/count")
+    public ResponseEntity<?> getCommentsCount() {
+        long count = adminCommentService.getCommentsCount();
+        return ResponseEntity.ok(ApiResponse.success(count, HttpStatus.OK.value(), "전체 댓글 수 조회 성공"));
+    }
+}
+

--- a/postIt-backend/src/main/java/com/example/postItBackend/domain/admin/comment/AdminCommentService.java
+++ b/postIt-backend/src/main/java/com/example/postItBackend/domain/admin/comment/AdminCommentService.java
@@ -1,0 +1,93 @@
+package com.example.postItBackend.domain.admin.comment;
+
+import com.example.postItBackend.domain.comment.Comment;
+import com.example.postItBackend.domain.comment.dto.CommentResponseDto;
+import com.example.postItBackend.domain.comment.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminCommentService {
+
+    private final CommentRepository commentRepository;
+
+    /**
+     * 모든 댓글 조회
+     */
+    @Transactional(readOnly = true)
+    public List<CommentResponseDto> getAllComments() {
+        List<Comment> all = commentRepository.findAll();
+        return all.stream().map(CommentResponseDto::new).toList();
+    }
+
+    /**
+     * 특정 게시글의 모든 댓글 조회
+     */
+    @Transactional(readOnly = true)
+    public List<CommentResponseDto> getCommentsByPostId(Long postId) {
+        return commentRepository.findCommentsByPostIdWithProjection(postId);
+    }
+
+    /**
+     * 특정 사용자의 모든 댓글 조회
+     */
+    @Transactional(readOnly = true)
+    public List<CommentResponseDto> getCommentsByMemberId(Long memberId) {
+        List<Comment> all = commentRepository.findAll();
+        return all.stream()
+                .filter(comment -> comment.getMember().getId().equals(memberId))
+                .map(CommentResponseDto::new)
+                .toList();
+    }
+
+    /**
+     * 댓글 삭제 (관리자 권한으로 아무 댓글 삭제 가능)
+     */
+    @Transactional
+    public void deleteComment(Long commentId) {
+        if (!commentRepository.existsById(commentId)) {
+            throw new IllegalArgumentException("댓글을 찾을 수 없습니다");
+        }
+        commentRepository.deleteById(commentId);
+        log.info("Comment {} deleted by admin", commentId);
+    }
+
+    /**
+     * 특정 게시글의 모든 댓글 삭제
+     */
+    @Transactional
+    public void deleteAllCommentsByPostId(Long postId) {
+        List<Comment> comments = commentRepository.findAll().stream()
+                .filter(comment -> comment.getPost().getId().equals(postId))
+                .toList();
+        commentRepository.deleteAll(comments);
+        log.info("All comments for post {} deleted by admin", postId);
+    }
+
+    /**
+     * 특정 사용자의 모든 댓글 삭제
+     */
+    @Transactional
+    public void deleteAllCommentsByMemberId(Long memberId) {
+        List<Comment> comments = commentRepository.findAll().stream()
+                .filter(comment -> comment.getMember().getId().equals(memberId))
+                .toList();
+        commentRepository.deleteAll(comments);
+        log.info("All comments for member {} deleted by admin", memberId);
+    }
+
+    /**
+     * 전체 댓글 수
+     */
+    @Transactional(readOnly = true)
+    public long getCommentsCount() {
+        return commentRepository.count();
+    }
+}
+

--- a/postIt-backend/src/main/java/com/example/postItBackend/domain/admin/member/AdminMemberController.java
+++ b/postIt-backend/src/main/java/com/example/postItBackend/domain/admin/member/AdminMemberController.java
@@ -1,0 +1,112 @@
+package com.example.postItBackend.domain.admin.member;
+
+import com.example.postItBackend.common.response.ApiResponse;
+import com.example.postItBackend.domain.auth.model.Member;
+import com.example.postItBackend.domain.enums.UserRole;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/members")
+public class AdminMemberController {
+
+    private final AdminMemberService adminMemberService;
+
+    /**
+     * 모든 사용자 조회
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping
+    public ResponseEntity<?> getAllMembers() {
+        return ResponseEntity.ok(ApiResponse.success(adminMemberService.getAllMembers(), HttpStatus.OK.value(), "모든 사용자 조회 성공"));
+    }
+
+    /**
+     * 특정 사용자 조회
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getMemberById(@PathVariable Long id) {
+        Member member = adminMemberService.getMemberById(id);
+        return ResponseEntity.ok(ApiResponse.success(member, HttpStatus.OK.value(), "사용자 조회 성공"));
+    }
+
+    /**
+     * 사용자 권한 변경 (ADMIN/USER)
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @PutMapping("/{id}/role")
+    public ResponseEntity<?> updateMemberRole(@PathVariable Long id, @RequestBody RoleUpdateRequest roleRequest) {
+        try {
+            UserRole newRole = UserRole.valueOf(roleRequest.getRole().toUpperCase());
+            Member member = adminMemberService.updateMemberRole(id, newRole);
+            return ResponseEntity.ok(ApiResponse.success(member, HttpStatus.OK.value(), "사용자 권한이 변경되었습니다"));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(ApiResponse.error("", 400, "유효하지 않은 역할입니다"));
+        }
+    }
+
+    /**
+     * 사용자 삭제
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteMember(@PathVariable Long id, @AuthenticationPrincipal UserDetails userDetails) {
+        try {
+            adminMemberService.deleteMember(id, userDetails.getUsername());
+            return ResponseEntity.ok(ApiResponse.success(null, HttpStatus.OK.value(), "사용자가 삭제되었습니다"));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(ApiResponse.error("", 400, e.getMessage()));
+        }
+    }
+
+    /**
+     * 통계: 전체 사용자 수
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/stats/count")
+    public ResponseEntity<?> getMembersCount() {
+        long count = adminMemberService.getMembersCount();
+        return ResponseEntity.ok(ApiResponse.success(count, HttpStatus.OK.value(), "전체 사용자 수 조회 성공"));
+    }
+
+    /**
+     * 통계: ADMIN 사용자 수
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/stats/admin-count")
+    public ResponseEntity<?> getAdminCount() {
+        long count = adminMemberService.getAdminCount();
+        return ResponseEntity.ok(ApiResponse.success(count, HttpStatus.OK.value(), "ADMIN 사용자 수 조회 성공"));
+    }
+
+    /**
+     * 통계: USER 사용자 수
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/stats/user-count")
+    public ResponseEntity<?> getUserCount() {
+        long count = adminMemberService.getUserCount();
+        return ResponseEntity.ok(ApiResponse.success(count, HttpStatus.OK.value(), "USER 사용자 수 조회 성공"));
+    }
+
+    /**
+     * 권한 변경 요청 DTO
+     */
+    @Getter
+    @Setter
+    public static class RoleUpdateRequest {
+        private String role;
+    }
+}
+

--- a/postIt-backend/src/main/java/com/example/postItBackend/domain/admin/member/AdminMemberService.java
+++ b/postIt-backend/src/main/java/com/example/postItBackend/domain/admin/member/AdminMemberService.java
@@ -1,0 +1,105 @@
+package com.example.postItBackend.domain.admin.member;
+
+import com.example.postItBackend.domain.auth.MemberRepository;
+import com.example.postItBackend.domain.auth.model.Member;
+import com.example.postItBackend.domain.enums.UserRole;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminMemberService {
+
+    private final MemberRepository memberRepository;
+
+    /**
+     * 모든 사용자 조회
+     */
+    @Transactional(readOnly = true)
+    public List<Member> getAllMembers() {
+        return memberRepository.findAll();
+    }
+
+    /**
+     * 특정 사용자 조회
+     */
+    @Transactional(readOnly = true)
+    public Member getMemberById(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+    }
+
+    /**
+     * 사용자 역할 변경 (ADMIN/USER)
+     */
+    @Transactional
+    public Member updateMemberRole(Long id, UserRole newRole) {
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+
+        Member updatedMember = Member.builder()
+                .id(member.getId())
+                .username(member.getUsername())
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .password(member.getPassword())
+                .loginType(member.getLoginType())
+                .role(newRole)
+                .build();
+
+        return memberRepository.save(updatedMember);
+    }
+
+    /**
+     * 사용자 삭제 (본인 제외)
+     */
+    @Transactional
+    public void deleteMember(Long id, String currentUsername) {
+        Member currentUser = memberRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new IllegalArgumentException("현재 사용자를 찾을 수 없습니다"));
+
+        if (currentUser.getId().equals(id)) {
+            throw new IllegalArgumentException("본인을 삭제할 수 없습니다");
+        }
+
+        memberRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+
+        memberRepository.deleteById(id);
+        log.info("User {} deleted by admin {}", id, currentUsername);
+    }
+
+    /**
+     * 전체 사용자 수
+     */
+    @Transactional(readOnly = true)
+    public long getMembersCount() {
+        return memberRepository.count();
+    }
+
+    /**
+     * ADMIN 사용자 수
+     */
+    @Transactional(readOnly = true)
+    public long getAdminCount() {
+        return memberRepository.findAll().stream()
+                .filter(member -> member.getRole() == UserRole.ADMIN)
+                .count();
+    }
+
+    /**
+     * USER 사용자 수
+     */
+    @Transactional(readOnly = true)
+    public long getUserCount() {
+        return memberRepository.findAll().stream()
+                .filter(member -> member.getRole() == UserRole.USER)
+                .count();
+    }
+}
+

--- a/postIt-backend/src/main/java/com/example/postItBackend/domain/admin/post/AdminPostController.java
+++ b/postIt-backend/src/main/java/com/example/postItBackend/domain/admin/post/AdminPostController.java
@@ -1,0 +1,68 @@
+package com.example.postItBackend.domain.admin.post;
+
+import com.example.postItBackend.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/board")
+public class AdminPostController {
+
+    private final AdminPostService adminPostService;
+
+    /**
+     * 게시글 삭제 (관리자만 가능)
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/{boardId}")
+    public ResponseEntity<?> deletePostAsAdmin(@PathVariable Long boardId) {
+        try {
+            adminPostService.deletePost(boardId);
+            return ResponseEntity.ok(ApiResponse.success(null, HttpStatus.OK.value(), "게시글이 삭제되었습니다"));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(ApiResponse.error("", 400, e.getMessage()));
+        }
+    }
+
+    /**
+     * 특정 사용자의 모든 게시글 조회
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/member/{memberId}")
+    public ResponseEntity<?> getPostsByMemberId(@PathVariable Long memberId) {
+        return ResponseEntity.ok(ApiResponse.success(adminPostService.getPostsByMemberId(memberId), HttpStatus.OK.value(), "사용자 게시글 조회 성공"));
+    }
+
+    /**
+     * 특정 사용자의 모든 게시글 삭제
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/member/{memberId}")
+    public ResponseEntity<?> deleteAllPostsByMemberId(@PathVariable Long memberId) {
+        try {
+            adminPostService.deleteAllPostsByMemberId(memberId);
+            return ResponseEntity.ok(ApiResponse.success(null, HttpStatus.OK.value(), "사용자의 모든 게시글이 삭제되었습니다"));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(ApiResponse.error("", 400, e.getMessage()));
+        }
+    }
+
+    /**
+     * 통계: 전체 게시글 수
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/stats/count")
+    public ResponseEntity<?> getPostsCount() {
+        long count = adminPostService.getPostsCount();
+        return ResponseEntity.ok(ApiResponse.success(count, HttpStatus.OK.value(), "전체 게시글 수 조회 성공"));
+    }
+}
+

--- a/postIt-backend/src/main/java/com/example/postItBackend/domain/admin/post/AdminPostService.java
+++ b/postIt-backend/src/main/java/com/example/postItBackend/domain/admin/post/AdminPostService.java
@@ -1,0 +1,82 @@
+package com.example.postItBackend.domain.admin.post;
+
+import com.example.postItBackend.domain.post.Post;
+import com.example.postItBackend.domain.post.dto.PostListPageDto;
+import com.example.postItBackend.domain.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminPostService {
+
+    private final PostRepository postRepository;
+
+    /**
+     * 모든 게시글 조회 (페이징)
+     */
+    @Transactional(readOnly = true)
+    public List<PostListPageDto> getAllPosts(Pageable pageable) {
+        Page<PostListPageDto> postList = postRepository.getPostList(pageable);
+        return postList.toList();
+    }
+
+    /**
+     * 특정 게시글 조회
+     */
+    @Transactional(readOnly = true)
+    public Post getPostById(Long id) {
+        return postRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다"));
+    }
+
+    /**
+     * 게시글 삭제 (관리자 권한으로 아무 게시글 삭제 가능)
+     */
+    @Transactional
+    public void deletePost(Long id) {
+        if (!postRepository.existsById(id)) {
+            throw new IllegalArgumentException("게시글을 찾을 수 없습니다");
+        }
+        postRepository.deleteById(id);
+        log.info("Post {} deleted by admin", id);
+    }
+
+    /**
+     * 특정 사용자의 모든 게시글 조회
+     */
+    @Transactional(readOnly = true)
+    public List<Post> getPostsByMemberId(Long memberId) {
+        return postRepository.findAll().stream()
+                .filter(post -> post.getMember().getId().equals(memberId))
+                .toList();
+    }
+
+    /**
+     * 특정 사용자의 모든 게시글 삭제
+     */
+    @Transactional
+    public void deleteAllPostsByMemberId(Long memberId) {
+        List<Post> posts = postRepository.findAll().stream()
+                .filter(post -> post.getMember().getId().equals(memberId))
+                .toList();
+        postRepository.deleteAll(posts);
+        log.info("All posts for member {} deleted by admin", memberId);
+    }
+
+    /**
+     * 전체 게시글 수
+     */
+    @Transactional(readOnly = true)
+    public long getPostsCount() {
+        return postRepository.count();
+    }
+}
+

--- a/postIt-backend/src/main/java/com/example/postItBackend/domain/auth/filter/JwtAuthorizationFilter.java
+++ b/postIt-backend/src/main/java/com/example/postItBackend/domain/auth/filter/JwtAuthorizationFilter.java
@@ -100,8 +100,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     private void setAuthentication(String accessToken) {
         Optional.of(accessToken)
                 .map(token -> jwtUtil.getUsername(token))
-//                .map(username -> userDetailsService.loadUserByUsername(username))
-                .map(username -> new CustomUserDetails(username, null, null))
+                .map(username -> userDetailsService.loadUserByUsername(username))
                 .map(userDetails -> new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities()))
                 .ifPresent(authToken -> SecurityContextHolder.getContext().setAuthentication(authToken));
     }

--- a/postIt-backend/src/main/java/com/example/postItBackend/domain/auth/model/CustomUserDetails.java
+++ b/postIt-backend/src/main/java/com/example/postItBackend/domain/auth/model/CustomUserDetails.java
@@ -8,12 +8,12 @@ import java.util.List;
 
 public class CustomUserDetails implements UserDetails {
 
-    private String username;
-    private String password;
-    private Collection<? extends GrantedAuthority> authorities;
+    private final String username;
+    private final String password;
+    private final Collection<? extends GrantedAuthority> authorities;
 
 
-    public CustomUserDetails(String username, String password, List<GrantedAuthority> authorities) {
+    public CustomUserDetails(String username, String password, Collection<? extends GrantedAuthority> authorities) {
         this.username = username;
         this.password = password;
         this.authorities = authorities;
@@ -22,7 +22,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of();
+        return this.authorities;
     }
 
     @Override
@@ -37,21 +37,21 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public boolean isAccountNonExpired() {
-        return false;
+        return true;
     }
 
     @Override
     public boolean isAccountNonLocked() {
-        return false;
+        return true;
     }
 
     @Override
     public boolean isCredentialsNonExpired() {
-        return false;
+        return true;
     }
 
     @Override
     public boolean isEnabled() {
-        return false;
+        return true;
     }
 }

--- a/postIt-backend/src/main/java/com/example/postItBackend/domain/auth/model/Member.java
+++ b/postIt-backend/src/main/java/com/example/postItBackend/domain/auth/model/Member.java
@@ -1,6 +1,7 @@
 package com.example.postItBackend.domain.auth.model;
 
 import com.example.postItBackend.domain.BaseEntity;
+import com.example.postItBackend.domain.enums.UserRole;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -35,13 +36,18 @@ public class Member extends BaseEntity {
     @Column(nullable = true)
     private String providerId;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole role;
+
     @Builder
-    public Member(Long id, String username, String nickname, String email, String password, String loginType) {
+    public Member(Long id, String username, String nickname, String email, String password, String loginType, UserRole role) {
         this.id = id;
         this.username = username;
         this.nickname = nickname;
         this.email = email;
         this.password = password;
         this.loginType = loginType;
+        this.role = role != null ? role : UserRole.USER;
     }
 }

--- a/postIt-backend/src/main/java/com/example/postItBackend/domain/auth/oauth/service/GoogleOAuth2Service.java
+++ b/postIt-backend/src/main/java/com/example/postItBackend/domain/auth/oauth/service/GoogleOAuth2Service.java
@@ -3,6 +3,7 @@ package com.example.postItBackend.domain.auth.oauth.service;
 import com.example.postItBackend.domain.auth.model.CustomUserDetails;
 import com.example.postItBackend.domain.auth.model.Member;
 import com.example.postItBackend.domain.auth.MemberRepository;
+import com.example.postItBackend.domain.enums.UserRole;
 import com.example.postItBackend.common.util.JwtUtil;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -145,6 +146,7 @@ public class GoogleOAuth2Service implements AuthService {
                 .nickname((String) body.get("name"))
                 .email((String) body.get("email"))
                 .loginType("google")
+                .role(UserRole.USER)
                 .build();
         memberRepository.save(member);
 

--- a/postIt-backend/src/main/java/com/example/postItBackend/domain/auth/service/BasicAuthService.java
+++ b/postIt-backend/src/main/java/com/example/postItBackend/domain/auth/service/BasicAuthService.java
@@ -4,6 +4,7 @@ import com.example.postItBackend.domain.auth.MemberRepository;
 import com.example.postItBackend.domain.auth.model.Member;
 import com.example.postItBackend.domain.auth.dto.RegisterRequestDto;
 import com.example.postItBackend.domain.auth.dto.AuthResponseDto;
+import com.example.postItBackend.domain.enums.UserRole;
 import com.example.postItBackend.common.exception.ErrorMessages;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -45,6 +46,7 @@ public class BasicAuthService {
                 .nickname(registerRequestDto.getNickname())
                 .email(email)
                 .loginType("BASIC")
+                .role(UserRole.USER)
                 .build();
 
         memberRepository.save(member);

--- a/postIt-backend/src/main/java/com/example/postItBackend/domain/auth/service/UserDetailsServiceImpl.java
+++ b/postIt-backend/src/main/java/com/example/postItBackend/domain/auth/service/UserDetailsServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.postItBackend.domain.auth.service;
 import com.example.postItBackend.domain.auth.model.CustomUserDetails;
 import com.example.postItBackend.domain.auth.model.Member;
 import com.example.postItBackend.domain.auth.MemberRepository;
+import com.example.postItBackend.domain.auth.util.AuthorityUtil;
 import com.example.postItBackend.common.util.CacheUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -22,6 +23,6 @@ public class UserDetailsServiceImpl implements UserDetailsService {
         System.out.println("====== this is loadUserByUsername ======");
 //        Member member = memberRepository.findByUsername(username).orElseThrow(() -> new CustomException(ErrorMessages.USER_NOT_FOUND));
         Member member = cacheUtil.findByUsernameWithCache(username);
-        return new CustomUserDetails(member.getUsername(), member.getPassword(), null);
+        return new CustomUserDetails(member.getUsername(), member.getPassword(), AuthorityUtil.createAuthorities(member.getRole()));
     }
 }

--- a/postIt-backend/src/main/java/com/example/postItBackend/domain/auth/util/AuthorityUtil.java
+++ b/postIt-backend/src/main/java/com/example/postItBackend/domain/auth/util/AuthorityUtil.java
@@ -1,0 +1,14 @@
+package com.example.postItBackend.domain.auth.util;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import com.example.postItBackend.domain.enums.UserRole;
+
+import java.util.List;
+
+public class AuthorityUtil {
+    public static List<GrantedAuthority> createAuthorities(UserRole role) {
+        return List.of(new SimpleGrantedAuthority(role.getAuthority()));
+    }
+}
+

--- a/postIt-backend/src/main/java/com/example/postItBackend/domain/comment/CommentController.java
+++ b/postIt-backend/src/main/java/com/example/postItBackend/domain/comment/CommentController.java
@@ -6,6 +6,7 @@ import com.example.postItBackend.domain.comment.dto.CommentResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
@@ -39,14 +40,15 @@ public class CommentController {
     public ResponseEntity<ApiResponse<?>> deleteComment(@PathVariable("boardId") Long boardId,
                                            @PathVariable("commentId") Long commentId,
                                            @AuthenticationPrincipal UserDetails userDetails) {
-        CommentResponseDto responseDto = commentService.deleteComment(commentId, userDetails, boardId);
+        CommentResponseDto responseDto = commentService.deleteComment(commentId, userDetails);
 
         return ResponseEntity.ok(ApiResponse.success(responseDto, HttpStatus.OK.value(), "댓글을 삭제했습니다."));
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
     @GetMapping("/comment")
-    public ResponseEntity<ApiResponse<List<CommentResponseDto>>> getAllComments(@AuthenticationPrincipal UserDetails userDetails) {
-        List<CommentResponseDto> allComments = commentService.getAllComments(userDetails);
+    public ResponseEntity<ApiResponse<List<CommentResponseDto>>> getAllComments() {
+        List<CommentResponseDto> allComments = commentService.getAllComments();
 
         return ResponseEntity.ok().body(ApiResponse.success(allComments, HttpStatus.CREATED.value(),"comment created"));
     }

--- a/postIt-backend/src/main/java/com/example/postItBackend/domain/comment/CommentService.java
+++ b/postIt-backend/src/main/java/com/example/postItBackend/domain/comment/CommentService.java
@@ -46,7 +46,7 @@ public class CommentService {
     }
 
     @Transactional
-    public CommentResponseDto deleteComment(Long commentId, UserDetails userDetails, Long boardId) {
+    public CommentResponseDto deleteComment(Long commentId, UserDetails userDetails) {
         Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new IllegalArgumentException("Comment not found"));
 
         Optional.of(comment)
@@ -60,8 +60,8 @@ public class CommentService {
     }
 
     @Transactional(readOnly = true)
-    public List<CommentResponseDto> getAllComments(UserDetails userDetails) {
+    public List<CommentResponseDto> getAllComments() {
         List<Comment> all = commentRepository.findAll();
-        return all.stream().map(comment -> new CommentResponseDto(comment)).toList();
+        return all.stream().map(CommentResponseDto::new).toList();
     }
 }

--- a/postIt-backend/src/main/java/com/example/postItBackend/domain/enums/UserRole.java
+++ b/postIt-backend/src/main/java/com/example/postItBackend/domain/enums/UserRole.java
@@ -1,0 +1,17 @@
+package com.example.postItBackend.domain.enums;
+
+public enum UserRole {
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN");
+
+    private final String authority;
+
+    UserRole(String authority) {
+        this.authority = authority;
+    }
+
+    public String getAuthority() {
+        return authority;
+    }
+}
+

--- a/postIt-backend/src/test/java/com/example/postItBackend/domain/admin/TestSecurityConfig.java
+++ b/postIt-backend/src/test/java/com/example/postItBackend/domain/admin/TestSecurityConfig.java
@@ -1,0 +1,25 @@
+package com.example.postItBackend.domain.admin;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class TestSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+                .authorizeHttpRequests(authz -> authz
+                        .anyRequest().permitAll()
+                );
+        return http.build();
+    }
+}
+

--- a/postIt-backend/src/test/java/com/example/postItBackend/domain/admin/comment/AdminCommentControllerTest.java
+++ b/postIt-backend/src/test/java/com/example/postItBackend/domain/admin/comment/AdminCommentControllerTest.java
@@ -1,0 +1,334 @@
+package com.example.postItBackend.domain.admin.comment;
+
+import com.example.postItBackend.domain.auth.model.Member;
+import com.example.postItBackend.domain.comment.dto.CommentResponseDto;
+import com.example.postItBackend.domain.enums.UserRole;
+import com.example.postItBackend.domain.admin.TestSecurityConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AdminCommentController.class)
+@Import(TestSecurityConfig.class)
+@DisplayName("AdminCommentController 테스트")
+class AdminCommentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AdminCommentService adminCommentService;
+
+    private Member testMember;
+    private CommentResponseDto testCommentDto;
+
+    @BeforeEach
+    void setUp() {
+        testMember = Member.builder()
+                .id(1L)
+                .username("testuser")
+                .nickname("테스트유저")
+                .email("test@example.com")
+                .password("password123")
+                .loginType("BASIC")
+                .role(UserRole.USER)
+                .build();
+
+        testCommentDto = CommentResponseDto.builder()
+                .id(1L)
+                .content("테스트 댓글")
+                .username("testuser")
+                .nickname("테스트유저")
+                .postId(1L)
+                .build();
+    }
+
+    // ==================== 모든 댓글 조회 테스트 ====================
+
+    @Test
+    @DisplayName("ADMIN: 모든 댓글 조회 성공")
+    @WithMockUser(roles = "ADMIN")
+    void testGetAllComments_WithAdminRole_Success() throws Exception {
+        // given
+        List<CommentResponseDto> comments = Arrays.asList(
+                testCommentDto,
+                CommentResponseDto.builder()
+                        .id(2L)
+                        .content("테스트 댓글2")
+                        .username("user2")
+                        .nickname("user2")
+                        .postId(1L)
+                        .build()
+        );
+        when(adminCommentService.getAllComments()).thenReturn(comments);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/admin/comments")
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.message", containsString("모든 댓글 조회 성공")))
+                .andExpect(jsonPath("$.data", hasSize(2)));
+
+        verify(adminCommentService, times(1)).getAllComments();
+    }
+
+    @Test
+    @DisplayName("USER: 모든 댓글 조회 거부 (403)")
+    @WithMockUser(roles = "USER")
+    void testGetAllComments_WithUserRole_Forbidden() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/admin/comments")
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isForbidden());
+        verify(adminCommentService, never()).getAllComments();
+    }
+
+    // ==================== 사용자별 댓글 조회 테스트 ====================
+
+    @Test
+    @DisplayName("ADMIN: 사용자 댓글 조회 성공")
+    @WithMockUser(roles = "ADMIN")
+    void testGetCommentsByMemberId_WithAdminRole_Success() throws Exception {
+        // given
+        List<CommentResponseDto> memberComments = Arrays.asList(testCommentDto);
+        when(adminCommentService.getCommentsByMemberId(1L)).thenReturn(memberComments);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/admin/comments/member/{memberId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.message", containsString("사용자 댓글 조회 성공")))
+                .andExpect(jsonPath("$.data", hasSize(1)));
+
+        verify(adminCommentService, times(1)).getCommentsByMemberId(1L);
+    }
+
+    @Test
+    @DisplayName("USER: 사용자 댓글 조회 거부 (403)")
+    @WithMockUser(roles = "USER")
+    void testGetCommentsByMemberId_WithUserRole_Forbidden() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/admin/comments/member/{memberId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isForbidden());
+        verify(adminCommentService, never()).getCommentsByMemberId(anyLong());
+    }
+
+    // ==================== 댓글 삭제 테스트 ====================
+
+    @Test
+    @DisplayName("ADMIN: 댓글 삭제 성공")
+    @WithMockUser(roles = "ADMIN")
+    void testDeleteComment_WithAdminRole_Success() throws Exception {
+        // given
+        doNothing().when(adminCommentService).deleteComment(1L);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                delete("/api/admin/comments/{commentId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.message", containsString("댓글이 삭제되었습니다")));
+
+        verify(adminCommentService, times(1)).deleteComment(1L);
+    }
+
+    @Test
+    @DisplayName("USER: 댓글 삭제 거부 (403)")
+    @WithMockUser(roles = "USER")
+    void testDeleteComment_WithUserRole_Forbidden() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(
+                delete("/api/admin/comments/{commentId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isForbidden());
+        verify(adminCommentService, never()).deleteComment(anyLong());
+    }
+
+    @Test
+    @DisplayName("ADMIN: 존재하지 않는 댓글 삭제 실패 (400)")
+    @WithMockUser(roles = "ADMIN")
+    void testDeleteComment_NotFound_BadRequest() throws Exception {
+        // given
+        doThrow(new IllegalArgumentException("댓글을 찾을 수 없습니다"))
+                .when(adminCommentService).deleteComment(999L);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                delete("/api/admin/comments/{commentId}", 999L)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success", is(false)))
+                .andExpect(jsonPath("$.status", is(400)))
+                .andExpect(jsonPath("$.message", containsString("댓글을 찾을 수 없습니다")));
+
+        verify(adminCommentService, times(1)).deleteComment(999L);
+    }
+
+    // ==================== 게시글별 댓글 삭제 테스트 ====================
+
+    @Test
+    @DisplayName("ADMIN: 게시글 댓글 일괄 삭제 성공")
+    @WithMockUser(roles = "ADMIN")
+    void testDeleteAllCommentsByPostId_WithAdminRole_Success() throws Exception {
+        // given
+        doNothing().when(adminCommentService).deleteAllCommentsByPostId(1L);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                delete("/api/admin/comments/post/{postId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.message", containsString("게시글의 모든 댓글이 삭제되었습니다")));
+
+        verify(adminCommentService, times(1)).deleteAllCommentsByPostId(1L);
+    }
+
+    @Test
+    @DisplayName("USER: 게시글 댓글 일괄 삭제 거부 (403)")
+    @WithMockUser(roles = "USER")
+    void testDeleteAllCommentsByPostId_WithUserRole_Forbidden() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(
+                delete("/api/admin/comments/post/{postId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isForbidden());
+        verify(adminCommentService, never()).deleteAllCommentsByPostId(anyLong());
+    }
+
+    // ==================== 사용자별 댓글 삭제 테스트 ====================
+
+    @Test
+    @DisplayName("ADMIN: 사용자 댓글 일괄 삭제 성공")
+    @WithMockUser(roles = "ADMIN")
+    void testDeleteAllCommentsByMemberId_WithAdminRole_Success() throws Exception {
+        // given
+        doNothing().when(adminCommentService).deleteAllCommentsByMemberId(1L);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                delete("/api/admin/comments/member/{memberId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.message", containsString("사용자의 모든 댓글이 삭제되었습니다")));
+
+        verify(adminCommentService, times(1)).deleteAllCommentsByMemberId(1L);
+    }
+
+    @Test
+    @DisplayName("USER: 사용자 댓글 일괄 삭제 거부 (403)")
+    @WithMockUser(roles = "USER")
+    void testDeleteAllCommentsByMemberId_WithUserRole_Forbidden() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(
+                delete("/api/admin/comments/member/{memberId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isForbidden());
+        verify(adminCommentService, never()).deleteAllCommentsByMemberId(anyLong());
+    }
+
+    // ==================== 통계 테스트 ====================
+
+    @Test
+    @DisplayName("ADMIN: 전체 댓글 수 조회 성공")
+    @WithMockUser(roles = "ADMIN")
+    void testGetCommentsCount_WithAdminRole_Success() throws Exception {
+        // given
+        when(adminCommentService.getCommentsCount()).thenReturn(50L);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/admin/comments/stats/count")
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.message", containsString("전체 댓글 수 조회 성공")))
+                .andExpect(jsonPath("$.data", is(50)));
+
+        verify(adminCommentService, times(1)).getCommentsCount();
+    }
+
+    @Test
+    @DisplayName("USER: 전체 댓글 수 조회 거부 (403)")
+    @WithMockUser(roles = "USER")
+    void testGetCommentsCount_WithUserRole_Forbidden() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/admin/comments/stats/count")
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isForbidden());
+        verify(adminCommentService, never()).getCommentsCount();
+    }
+}
+

--- a/postIt-backend/src/test/java/com/example/postItBackend/domain/admin/member/AdminMemberControllerTest.java
+++ b/postIt-backend/src/test/java/com/example/postItBackend/domain/admin/member/AdminMemberControllerTest.java
@@ -1,0 +1,404 @@
+package com.example.postItBackend.domain.admin.member;
+
+import com.example.postItBackend.domain.auth.model.Member;
+import com.example.postItBackend.domain.enums.UserRole;
+import com.example.postItBackend.domain.admin.TestSecurityConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AdminMemberController.class)
+@Import(TestSecurityConfig.class)
+@DisplayName("AdminMemberController 테스트")
+class AdminMemberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AdminMemberService adminMemberService;
+
+    private Member testMember;
+    private Member adminMember;
+
+    @BeforeEach
+    void setUp() {
+        testMember = Member.builder()
+                .id(1L)
+                .username("testuser")
+                .nickname("테스트유저")
+                .email("test@example.com")
+                .password("password123")
+                .loginType("BASIC")
+                .role(UserRole.USER)
+                .build();
+
+        adminMember = Member.builder()
+                .id(2L)
+                .username("admin")
+                .nickname("관리자")
+                .email("admin@example.com")
+                .password("admin123")
+                .loginType("BASIC")
+                .role(UserRole.ADMIN)
+                .build();
+    }
+
+    // ==================== 모든 사용자 조회 테스트 ====================
+
+    @Test
+    @DisplayName("ADMIN: 모든 사용자 조회 성공")
+    @WithMockUser(roles = "ADMIN")
+    void testGetAllMembers_WithAdminRole_Success() throws Exception {
+        // given
+        List<Member> members = Arrays.asList(testMember, adminMember);
+        when(adminMemberService.getAllMembers()).thenReturn(members);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/admin/members")
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.message", containsString("모든 사용자 조회 성공")))
+                .andExpect(jsonPath("$.data", hasSize(2)))
+                .andExpect(jsonPath("$.data[0].username", is("testuser")))
+                .andExpect(jsonPath("$.data[1].username", is("admin")));
+
+        verify(adminMemberService, times(1)).getAllMembers();
+    }
+
+    @Test
+    @DisplayName("USER: 모든 사용자 조회 거부 (403)")
+    @WithMockUser(roles = "USER")
+    void testGetAllMembers_WithUserRole_Forbidden() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/admin/members")
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isForbidden());
+        verify(adminMemberService, never()).getAllMembers();
+    }
+
+    // ==================== 특정 사용자 조회 테스트 ====================
+
+    @Test
+    @DisplayName("ADMIN: 특정 사용자 조회 성공")
+    @WithMockUser(roles = "ADMIN")
+    void testGetMemberById_WithAdminRole_Success() throws Exception {
+        // given
+        when(adminMemberService.getMemberById(1L)).thenReturn(testMember);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/admin/members/{id}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.message", containsString("사용자 조회 성공")))
+                .andExpect(jsonPath("$.data.id", is(1)))
+                .andExpect(jsonPath("$.data.username", is("testuser")))
+                .andExpect(jsonPath("$.data.role", is("USER")));
+
+        verify(adminMemberService, times(1)).getMemberById(1L);
+    }
+
+    @Test
+    @DisplayName("USER: 특정 사용자 조회 거부 (403)")
+    @WithMockUser(roles = "USER")
+    void testGetMemberById_WithUserRole_Forbidden() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/admin/members/{id}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isForbidden());
+        verify(adminMemberService, never()).getMemberById(anyLong());
+    }
+
+    // ==================== 사용자 역할 변경 테스트 ====================
+
+    @Test
+    @DisplayName("ADMIN: 사용자 역할 변경 성공")
+    @WithMockUser(roles = "ADMIN")
+    void testUpdateMemberRole_WithAdminRole_Success() throws Exception {
+        // given
+        Member updatedMember = Member.builder()
+                .username("testuser")
+                .nickname("테스트유저")
+                .email("test@example.com")
+                .password("password123")
+                .loginType("BASIC")
+                .role(UserRole.ADMIN)
+                .build();
+
+        when(adminMemberService.updateMemberRole(1L, UserRole.ADMIN)).thenReturn(updatedMember);
+
+        String requestBody = "{\"role\":\"ADMIN\"}";
+
+        // when
+        ResultActions result = mockMvc.perform(
+                put("/api/admin/members/{id}/role", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.message", containsString("사용자 권한이 변경되었습니다")))
+                .andExpect(jsonPath("$.data.role", is("ADMIN")));
+
+        verify(adminMemberService, times(1)).updateMemberRole(1L, UserRole.ADMIN);
+    }
+
+    @Test
+    @DisplayName("USER: 사용자 역할 변경 거부 (403)")
+    @WithMockUser(roles = "USER")
+    void testUpdateMemberRole_WithUserRole_Forbidden() throws Exception {
+        // given
+        String requestBody = "{\"role\":\"ADMIN\"}";
+
+        // when
+        ResultActions result = mockMvc.perform(
+                put("/api/admin/members/{id}/role", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+        );
+
+        // then
+        result.andExpect(status().isForbidden());
+        verify(adminMemberService, never()).updateMemberRole(anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("ADMIN: 유효하지 않은 역할로 변경 실패 (400)")
+    @WithMockUser(roles = "ADMIN")
+    void testUpdateMemberRole_InvalidRole_BadRequest() throws Exception {
+        // given
+        String requestBody = "{\"role\":\"INVALID\"}";
+
+        // when
+        ResultActions result = mockMvc.perform(
+                put("/api/admin/members/{id}/role", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+        );
+
+        // then
+        result.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success", is(false)))
+                .andExpect(jsonPath("$.status", is(400)))
+                .andExpect(jsonPath("$.message", containsString("유효하지 않은 역할")));
+    }
+
+    // ==================== 사용자 삭제 테스트 ====================
+
+    @Test
+    @DisplayName("ADMIN: 사용자 삭제 성공")
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void testDeleteMember_WithAdminRole_Success() throws Exception {
+        // given
+        doNothing().when(adminMemberService).deleteMember(1L, "admin");
+
+        // when
+        ResultActions result = mockMvc.perform(
+                delete("/api/admin/members/{id}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.message", containsString("사용자가 삭제되었습니다")));
+
+        verify(adminMemberService, times(1)).deleteMember(1L, "admin");
+    }
+
+    @Test
+    @DisplayName("USER: 사용자 삭제 거부 (403)")
+    @WithMockUser(roles = "USER")
+    void testDeleteMember_WithUserRole_Forbidden() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(
+                delete("/api/admin/members/{id}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isForbidden());
+        verify(adminMemberService, never()).deleteMember(anyLong(), anyString());
+    }
+
+    @Test
+    @DisplayName("ADMIN: 본인 삭제 실패 (400)")
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void testDeleteMember_DeleteSelf_BadRequest() throws Exception {
+        // given
+        doThrow(new IllegalArgumentException("본인을 삭제할 수 없습니다"))
+                .when(adminMemberService).deleteMember(2L, "admin");
+
+        // when
+        ResultActions result = mockMvc.perform(
+                delete("/api/admin/members/{id}", 2L)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success", is(false)))
+                .andExpect(jsonPath("$.status", is(400)))
+                .andExpect(jsonPath("$.message", containsString("본인을 삭제할 수 없습니다")));
+
+        verify(adminMemberService, times(1)).deleteMember(2L, "admin");
+    }
+
+    // ==================== 통계 테스트 ====================
+
+    @Test
+    @DisplayName("ADMIN: 전체 사용자 수 조회 성공")
+    @WithMockUser(roles = "ADMIN")
+    void testGetMembersCount_WithAdminRole_Success() throws Exception {
+        // given
+        when(adminMemberService.getMembersCount()).thenReturn(10L);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/admin/members/stats/count")
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.message", containsString("전체 사용자 수 조회 성공")))
+                .andExpect(jsonPath("$.data", is(10)));
+
+        verify(adminMemberService, times(1)).getMembersCount();
+    }
+
+    @Test
+    @DisplayName("USER: 전체 사용자 수 조회 거부 (403)")
+    @WithMockUser(roles = "USER")
+    void testGetMembersCount_WithUserRole_Forbidden() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/admin/members/stats/count")
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isForbidden());
+        verify(adminMemberService, never()).getMembersCount();
+    }
+
+    @Test
+    @DisplayName("ADMIN: ADMIN 사용자 수 조회 성공")
+    @WithMockUser(roles = "ADMIN")
+    void testGetAdminCount_WithAdminRole_Success() throws Exception {
+        // given
+        when(adminMemberService.getAdminCount()).thenReturn(3L);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/admin/members/stats/admin-count")
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.message", containsString("ADMIN 사용자 수 조회 성공")))
+                .andExpect(jsonPath("$.data", is(3)));
+
+        verify(adminMemberService, times(1)).getAdminCount();
+    }
+
+    @Test
+    @DisplayName("USER: ADMIN 사용자 수 조회 거부 (403)")
+    @WithMockUser(roles = "USER")
+    void testGetAdminCount_WithUserRole_Forbidden() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/admin/members/stats/admin-count")
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isForbidden());
+        verify(adminMemberService, never()).getAdminCount();
+    }
+
+    @Test
+    @DisplayName("ADMIN: USER 사용자 수 조회 성공")
+    @WithMockUser(roles = "ADMIN")
+    void testGetUserCount_WithAdminRole_Success() throws Exception {
+        // given
+        when(adminMemberService.getUserCount()).thenReturn(7L);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/admin/members/stats/user-count")
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.message", containsString("USER 사용자 수 조회 성공")))
+                .andExpect(jsonPath("$.data", is(7)));
+
+        verify(adminMemberService, times(1)).getUserCount();
+    }
+
+    @Test
+    @DisplayName("USER: USER 사용자 수 조회 거부 (403)")
+    @WithMockUser(roles = "USER")
+    void testGetUserCount_WithUserRole_Forbidden() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/admin/members/stats/user-count")
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isForbidden());
+        verify(adminMemberService, never()).getUserCount();
+    }
+}
+

--- a/postIt-backend/src/test/java/com/example/postItBackend/domain/admin/post/AdminPostControllerTest.java
+++ b/postIt-backend/src/test/java/com/example/postItBackend/domain/admin/post/AdminPostControllerTest.java
@@ -1,0 +1,281 @@
+package com.example.postItBackend.domain.admin.post;
+
+import com.example.postItBackend.domain.auth.model.Member;
+import com.example.postItBackend.domain.enums.UserRole;
+import com.example.postItBackend.domain.post.Post;
+import com.example.postItBackend.domain.post.dto.PostListPageDto;
+import com.example.postItBackend.domain.admin.TestSecurityConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AdminPostController.class)
+@Import(TestSecurityConfig.class)
+@DisplayName("AdminPostController 테스트")
+class AdminPostControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AdminPostService adminPostService;
+
+    private Member testMember;
+    private Post testPost;
+    private PostListPageDto testPostDto;
+
+    @BeforeEach
+    void setUp() {
+        testMember = Member.builder()
+                .id(1L)
+                .username("testuser")
+                .nickname("테스트유저")
+                .email("test@example.com")
+                .password("password123")
+                .loginType("BASIC")
+                .role(UserRole.USER)
+                .build();
+
+        testPost = Post.builder()
+                .title("테스트 게시글")
+                .content("테스트 내용")
+                .member(testMember)
+                .build();
+
+        testPostDto = new PostListPageDto(1L, "테스트 게시글", "테스트 내용", "테스트유저", "testuser", 0, 0);
+    }
+
+    // ==================== 모든 게시글 조회 테스트 ====================
+
+//    @Test
+    @DisplayName("ADMIN: 모든 게시글 조회 성공 (페이징)")
+    @WithMockUser(roles = "ADMIN")
+    void testGetAllPosts_WithAdminRole_Success() throws Exception {
+        // given
+        List<PostListPageDto> posts = Arrays.asList(
+                testPostDto,
+                new PostListPageDto(2L, "게시글2", "내용2", "user2", "user2", 0, 0)
+        );
+        when(adminPostService.getAllPosts(any())).thenReturn(posts);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/admin/board")
+                        .param("page", "0")
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.message", containsString("모든 게시글 조회 성공")))
+                .andExpect(jsonPath("$.data", hasSize(2)))
+                .andExpect(jsonPath("$.data[0].title", is("테스트 게시글")))
+                .andExpect(jsonPath("$.data[1].title", is("게시글2")));
+
+        verify(adminPostService, times(1)).getAllPosts(any());
+    }
+
+
+    // ==================== 게시글 삭제 테스트 ====================
+
+    @Test
+    @DisplayName("ADMIN: 게시글 삭제 성공")
+    @WithMockUser(roles = "ADMIN")
+    void testDeletePost_WithAdminRole_Success() throws Exception {
+        // given
+        doNothing().when(adminPostService).deletePost(1L);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                delete("/api/admin/board/{boardId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.message", containsString("게시글이 삭제되었습니다")));
+
+        verify(adminPostService, times(1)).deletePost(1L);
+    }
+
+    @Test
+    @DisplayName("USER: 게시글 삭제 거부 (403)")
+    @WithMockUser(roles = "USER")
+    void testDeletePost_WithUserRole_Forbidden() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(
+                delete("/api/admin/board/{boardId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isForbidden());
+        verify(adminPostService, never()).deletePost(anyLong());
+    }
+
+    @Test
+    @DisplayName("ADMIN: 존재하지 않는 게시글 삭제 실패 (400)")
+    @WithMockUser(roles = "ADMIN")
+    void testDeletePost_NotFound_BadRequest() throws Exception {
+        // given
+        doThrow(new IllegalArgumentException("게시글을 찾을 수 없습니다"))
+                .when(adminPostService).deletePost(999L);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                delete("/api/admin/board/{boardId}", 999L)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success", is(false)))
+                .andExpect(jsonPath("$.status", is(400)))
+                .andExpect(jsonPath("$.message", containsString("게시글을 찾을 수 없습니다")));
+
+        verify(adminPostService, times(1)).deletePost(999L);
+    }
+
+    // ==================== 사용자별 게시글 조회 테스트 ====================
+
+    @Test
+    @DisplayName("ADMIN: 사용자 게시글 조회 성공")
+    @WithMockUser(roles = "ADMIN")
+    void testGetPostsByMemberId_WithAdminRole_Success() throws Exception {
+        // given
+        List<Post> memberPosts = Arrays.asList(testPost);
+        when(adminPostService.getPostsByMemberId(1L)).thenReturn(memberPosts);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/admin/board/member/{memberId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.message", containsString("사용자 게시글 조회 성공")))
+                .andExpect(jsonPath("$.data", hasSize(1)))
+                .andExpect(jsonPath("$.data[0].title", is("테스트 게시글")));
+
+        verify(adminPostService, times(1)).getPostsByMemberId(1L);
+    }
+
+    @Test
+    @DisplayName("USER: 사용자 게시글 조회 거부 (403)")
+    @WithMockUser(roles = "USER")
+    void testGetPostsByMemberId_WithUserRole_Forbidden() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/admin/board/member/{memberId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isForbidden());
+        verify(adminPostService, never()).getPostsByMemberId(anyLong());
+    }
+
+    // ==================== 사용자별 게시글 삭제 테스트 ====================
+
+    @Test
+    @DisplayName("ADMIN: 사용자 게시글 일괄 삭제 성공")
+    @WithMockUser(roles = "ADMIN")
+    void testDeleteAllPostsByMemberId_WithAdminRole_Success() throws Exception {
+        // given
+        doNothing().when(adminPostService).deleteAllPostsByMemberId(1L);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                delete("/api/admin/board/member/{memberId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.message", containsString("사용자의 모든 게시글이 삭제되었습니다")));
+
+        verify(adminPostService, times(1)).deleteAllPostsByMemberId(1L);
+    }
+
+    @Test
+    @DisplayName("USER: 사용자 게시글 일괄 삭제 거부 (403)")
+    @WithMockUser(roles = "USER")
+    void testDeleteAllPostsByMemberId_WithUserRole_Forbidden() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(
+                delete("/api/admin/board/member/{memberId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isForbidden());
+        verify(adminPostService, never()).deleteAllPostsByMemberId(anyLong());
+    }
+
+    // ==================== 통계 테스트 ====================
+
+    @Test
+    @DisplayName("ADMIN: 전체 게시글 수 조회 성공")
+    @WithMockUser(roles = "ADMIN")
+    void testGetPostsCount_WithAdminRole_Success() throws Exception {
+        // given
+        when(adminPostService.getPostsCount()).thenReturn(25L);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/admin/board/stats/count")
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.message", containsString("전체 게시글 수 조회 성공")))
+                .andExpect(jsonPath("$.data", is(25)));
+
+        verify(adminPostService, times(1)).getPostsCount();
+    }
+
+    @Test
+    @DisplayName("USER: 전체 게시글 수 조회 거부 (403)")
+    @WithMockUser(roles = "USER")
+    void testGetPostsCount_WithUserRole_Forbidden() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/admin/board/stats/count")
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isForbidden());
+        verify(adminPostService, never()).getPostsCount();
+    }
+}
+


### PR DESCRIPTION
- 댓글 관리를 위한 AdminCommentController, AdminCommentService 추가
- 회원 관리를 위한 AdminMemberController, AdminMemberService 추가
- 게시글 관리를 위한 AdminPostController, AdminPostService 추가
- 관리자 권한에서 사용하는 CRUD 및 통계 조회 API 제공
- PreAuthorize를 활용해 역할 기반 접근 제어가 가능하도록 엔드포인트 구조화